### PR TITLE
Develop hot fix 

### DIFF
--- a/src/main/java/org/agmip/translators/dssat/DssatControllerOutput.java
+++ b/src/main/java/org/agmip/translators/dssat/DssatControllerOutput.java
@@ -108,6 +108,7 @@ public class DssatControllerOutput extends DssatCommonOutput {
                     soilArrTmp.add((HashMap) soilTmp.get("soil"));
                     wthArrTmp.add(wthTmp);
                     rootArr.get(j).put("wst_id", getObjectOr(wthTmp, "wst_id", wth_id));
+                    rootArr.get(j).put("soil_id", getObjectOr(soilTmp, "soil_id", wth_id));
                 }
                 expData.put("soil", soilArrTmp);
                 expData.put("weather", wthArrTmp);

--- a/src/main/java/org/agmip/translators/dssat/DssatXFileOutput.java
+++ b/src/main/java/org/agmip/translators/dssat/DssatXFileOutput.java
@@ -258,7 +258,7 @@ public class DssatXFileOutput extends DssatCommonOutput {
                 copyItem(flData, getObjectOr(rootData, "dssat_info", new HashMap()), "fhdur");
                 // remove the "_trno" in the soil_id when soil analysis is available
                 String soilId = getValueOr(flData, "soil_id", "");
-                if (soilId.length() > 10 && soilId.matches("\\w+_\\d+")) {
+                if (soilId.length() > 10 && soilId.matches("\\w+_\\d+") || soilId.length() < 8) {
                     flData.put("soil_id", getSoilID(flData));
                 }
                 flNum = setSecDataArr(flData, flArr);


### PR DESCRIPTION
Fix the issue that when original soil_id is not match with DSSAT format and the dataset need experiment combination, then the output XFile will keep using original soil_id but soil file will using revised soil_id
