### PR TITLE
Develop hot fix 

### DIFF
--- a/src/main/java/org/agmip/translators/dssat/DssatCommonOutput.java
+++ b/src/main/java/org/agmip/translators/dssat/DssatCommonOutput.java
@@ -166,11 +166,11 @@ public abstract class DssatCommonOutput implements TranslatorOutput {
     protected String getExName(Map result) {
 
         String ret = getValueOr(result, "exname", "");
-        if (ret.contains(".")) {
+        if (ret.matches("\\w+\\.\\w{2}[Xx]")) {
             ret = ret.substring(0, ret.length() - 1).replace(".", "");
         }
         // TODO need to be updated with a translate rule for other models' exname
-        if (ret.matches("[\\w ]+(_+\\d+)+$")) {
+        if (ret.matches(".+(_+\\d+)+$")) {
             ret = ret.replaceAll("(_+\\d+)+$", "");
         }
 


### PR DESCRIPTION
Fix the issue that some raw data from spreadtheet might contain "." which lead grouping process incorrectly. To fix it, revising the matching regulation to make more strictly matching.
